### PR TITLE
docs(guides): add developer debugging guide and link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,7 +407,6 @@ For more information about OneMount:
 ### Developer Documentation
 * [Development Guidelines](docs/DEVELOPMENT.md) - Information about the project structure, tech stack, and best practices
 * [Debugging Guide](docs/guides/debugging.md) - Developer-focused procedures for logs, tracing, and quick diagnostics
-
 * [OneMount Consolidated Action Plan](docs/OneMount-Consolidated-Action-Plan.md) - **Current project status, priorities, and AI implementation prompts**
 * [Solo Developer AI Process](docs/Solo-Developer-AI-Process.md) - Project-agnostic development methodology
 * [Documentation Consolidation Summary](docs/0-project-management/DOCUMENTATION_CONSOLIDATION_SUMMARY.md) - Overview of recent documentation updates

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Mount your Microsoft OneDrive account as a native filesystem on Linux.
 
 ---
 
-This repository was forked from [Jeff Stafford's one-driver](https://github.com/jstaf/one-driver) repository. Extensive changes have been made, leading to the decision to rename the project. 
+This repository was forked from [Jeff Stafford's one-driver](https://github.com/jstaf/one-driver) repository. Extensive changes have been made, leading to the decision to rename the project.
 
 ---
 
@@ -61,7 +61,7 @@ by typing `man OneMount` or get a quick summary with `OneMount --help`.
 
 You can also view statistics about your OneDrive cache without mounting by using
 the `--stats` flag: `OneMount --stats /path/to/mount/onedrive/at`. This will
-display information about the metadata cache, content cache, upload queue, 
+display information about the metadata cache, content cache, upload queue,
 file statuses, and the embedded bbolt database used for persistent storage.
 The stats command now includes detailed metadata analysis such as file type distribution,
 directory depth statistics, file size distribution, and file age information derived
@@ -406,6 +406,8 @@ For more information about OneMount:
 
 ### Developer Documentation
 * [Development Guidelines](docs/DEVELOPMENT.md) - Information about the project structure, tech stack, and best practices
+* [Debugging Guide](docs/guides/debugging.md) - Developer-focused procedures for logs, tracing, and quick diagnostics
+
 * [OneMount Consolidated Action Plan](docs/OneMount-Consolidated-Action-Plan.md) - **Current project status, priorities, and AI implementation prompts**
 * [Solo Developer AI Process](docs/Solo-Developer-AI-Process.md) - Project-agnostic development methodology
 * [Documentation Consolidation Summary](docs/0-project-management/DOCUMENTATION_CONSOLIDATION_SUMMARY.md) - Overview of recent documentation updates

--- a/docs/guides/debugging.md
+++ b/docs/guides/debugging.md
@@ -55,6 +55,12 @@ Related docs: [Logging Guidelines](logging-guidelines.md), [Logging Examples](lo
 - Python Nemo extension path: `internal/nemo/src/nemo-onemount.py`.
 - Focus on D-Bus signals and method calls rather than UI when isolating issues.
 - Use `dbus-monitor` to confirm events arrive; compare with Nemo log output if available.
+- Example: monitor OneMount FileManager signals only:
+
+  ```bash
+  dbus-monitor --session "type='signal',sender='org.onemount',interface='org.onemount.FileManager'"
+  ```
+
 
 ## Token safety (testing)
 - Do NOT use production tokens in tests.

--- a/docs/guides/debugging.md
+++ b/docs/guides/debugging.md
@@ -1,0 +1,74 @@
+# Debugging Guide (Developers)
+
+Purpose: Practical procedures to diagnose issues quickly without changing dependencies or system state. For end-user fixes, see the Troubleshooting Guide.
+
+Related docs: [Logging Guidelines](logging-guidelines.md), [Logging Examples](logging-examples.md), [Development CLI Guide](../../scripts/README.md), [Docker Dev Workflow](../docker-development-workflow.md), [Test Architecture](../2-architecture-and-design/test-architecture-design.md), [Troubleshooting Guide](troubleshooting-guide.md).
+
+## Quick checklist
+- Reproduce with minimal steps and note exact command/args.
+- Capture logs (see below) and environment details (distro, kernel, OneMount version).
+- Validate with latest main or the tagged build you are testing.
+- Avoid using production auth tokens for tests (see token safety below).
+
+## Logging and verbosity
+- One-off verbose run (foreground):
+  - GUI launcher: run the CLI directly to capture logs
+    - `ONEMOUNT_DEBUG=1 onemount /path/to/mount`
+  - Help and args: `onemount --help`
+- Systemd user logs (packaged service):
+  - Show recent logs for all OneMount user units:
+    - `journalctl --user -u onemount@* -S today -o short-iso`
+  - Follow live logs:
+    - `journalctl --user -u onemount@* -f`
+- Increase detail via environment:
+  - `ONEMOUNT_DEBUG=1` enables verbose output in many paths.
+  - For targeted areas, prefer component-specific flags or config if available.
+
+## Common diagnostics
+- Filesystem mount check:
+  - Verify mount exists and is accessible: `mount | grep -i onemount` and `ls -l /path/to/mount`
+- D-Bus integration
+  - Monitor signals: `dbus-monitor --session "type='signal',sender='org.onemount'"`
+  - List names: `gdbus list --session`
+- Graph API boundaries (no real tokens in logs):
+  - Confirm environment-based proxies are off if testing local failures.
+  - Simulate offline: disable network for the process/sandbox and observe retry behavior.
+
+## Using the development CLI (scripts/dev.py)
+- Show environment status: `./scripts/dev info`
+- Run tests with coverage (fast iteration):
+  - `./scripts/dev test coverage --threshold-line 80`
+  - Smallest scope first (package/file) when possible.
+- System tests (controlled): `./scripts/dev test system --category smoke`
+- Quality analysis: `./scripts/dev analyze test-suite --mode resolve`
+- Build packages (no push): `./scripts/dev build deb --docker`
+- Get help: `./scripts/dev --help` and subcommand `--help`.
+
+## Docker test shell (manual repro)
+- Launch a disposable test shell:
+  - `docker compose -f docker/compose/docker-compose.test.yml run --rm shell`
+- Inside shell:
+  - Run CLI: `onemount --help` or targeted commands.
+  - Mount to a temp path under `/workspace` and validate basics.
+
+## Nemo extension and D-Bus tips
+- Python Nemo extension path: `internal/nemo/src/nemo-onemount.py`.
+- Focus on D-Bus signals and method calls rather than UI when isolating issues.
+- Use `dbus-monitor` to confirm events arrive; compare with Nemo log output if available.
+
+## Token safety (testing)
+- Do NOT use production tokens in tests.
+  - Production location: `~/.cache/onemount/auth_tokens.json` — keep protected.
+- OneMount stores test-time tokens in cache subdirectories named after the mount path; prefer isolated mounts like `/tmp/onemount-test-*`.
+- Use scripts under `scripts/` (e.g., `setup-test-auth.sh`) to prepare safe test credentials.
+
+## Capturing a useful bug report (developers)
+- Commands executed, exact output (trim secrets), environment (distro, kernel, desktop, versions).
+- Log excerpts around the failure with timestamps.
+- If concurrency-related, note whether the issue reproduces with a single file op.
+- For offline/online transitions, include the timing of network loss/restore.
+
+## Next steps
+- If a defect is confirmed, add a minimal failing test first (unit or integration) before code changes.
+- Link logs and reproduction notes in the PR/issue; keep sensitive data out of the repo.
+


### PR DESCRIPTION
Add developer debugging guide with practical diagnostic procedures

This PR introduces comprehensive debugging documentation to improve developer productivity when diagnosing OneMount issues:

• **New debugging guide** (`docs/guides/debugging.md`) covering:
  - Logging and verbosity controls (`ONEMOUNT_DEBUG`, `journalctl` usage)
  - Development CLI workflows (`scripts/dev.py` commands)
  - Docker test shell procedures for isolated reproduction
  - D-Bus integration diagnostics and Nemo extension tips
  - Token safety practices for testing environments

• **Updated README** to include the debugging guide in the Developer Documentation section for better discoverability

The guide provides actionable procedures for quick issue diagnosis without changing dependencies or system state, complementing existing troubleshooting documentation with developer-focused workflows.

Fixes #34

---
*🤖 This description was generated automatically. Please react with 👍 if it's helpful or 👎 if it needs improvement.*